### PR TITLE
fix: Not override poll_needed method

### DIFF
--- a/pyNukiBT/nuki.py
+++ b/pyNukiBT/nuki.py
@@ -306,7 +306,7 @@ class NukiDevice:
             logger.debug(f"State: {self.last_state}")
             if update_config:
                 # todo: update config directly?
-                self.poll_needed = True
+                self._poll_needed = True
             self._fire_callbacks()
 
         elif msg.command == self._const.NukiCommand.STATUS:


### PR DESCRIPTION
References the correct attribute instead of the method.

This issue was causing the following error in my Home Assistant instance.

```
2023-10-28 19:11:22.048 ERROR (MainThread) [homeassistant.components.bluetooth.manager] Error in bluetooth callback
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/manager.py", line 590, in scanner_adv_received
    callback(service_info, BluetoothChange.ADVERTISEMENT)
  File "/config/custom_components/hass_nuki_bt/coordinator.py", line 142, in _async_handle_bluetooth_event
    super()._async_handle_bluetooth_event(service_info, change)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/active_update_coordinator.py", line 170, in _async_handle_bluetooth_event
    if self.needs_poll(service_info):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/active_update_coordinator.py", line 114, in needs_poll
    return self._needs_poll_method(service_info, poll_age)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/hass_nuki_bt/coordinator.py", line 102, in _needs_poll
    return self.device.poll_needed(seconds_since_last_poll)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```