### PR TITLE
Use BLEDevice instead of the bluetooth mac address to connect

### DIFF
--- a/pyNukiBT/nuki.py
+++ b/pyNukiBT/nuki.py
@@ -378,7 +378,8 @@ class NukiDevice:
         async with self._connect_lock:
             if not self._client:
                 self._client = BleakClient(
-                    self._address, timeout=self.connection_timeout
+                    BLEDevice(address=self._address, details=None, name=self._name, rssi=self.rssi),
+                    timeout=self.connection_timeout
                 )
             if self._client.is_connected:
                 logger.info("Connected")


### PR DESCRIPTION
The plugin is triggering this HA warning:
```
homeassistant    | 2023-11-14 12:32:26.701 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'hass_nuki_bt' attempted to call BleakClient with an address instead of a BLEDevice at custom_components/hass_nuki_bt/config_flow.py, line 151: ret = await device.pair(), please create a bug report at https://github.com/ronengr/hass_nuki_bt/issues
```
by using a deprecated way of connecting to Bluetooth devices.

With this PR it is using a BLEDevice class with the available data found inside the NukiDevice class.

Nuki 3.0 is pairing, connecting and working perfectly fine with this PR.
Dont know if anything else will be affected.
