### PR TITLE
Reduce log spam caused by each advertisement packet

### DIFF
--- a/pyNukiBT/nuki.py
+++ b/pyNukiBT/nuki.py
@@ -93,7 +93,7 @@ class NukiDevice:
             if manufacturer_data[0] != 0x02:
                 # Ignore HomeKit advertisement
                 return
-            logger.info(f"Nuki: {device.address}, RSSI: {advertisement_data.rssi}")
+            logger.debug(f"Nuki: {device.address}, RSSI: {advertisement_data.rssi}")
             tx_p = manufacturer_data[-1]
             if self.just_got_beacon:
                 logger.info(f"Ignoring duplicate beacon from Nuki {device.address}")


### PR DESCRIPTION
With usual default logging level set to INFO, each advertisement packet triggers a log message with MAC address and RSSI in the HA log. It's not useful in normal use, so reduce the verbosity to DEBUG.